### PR TITLE
Minor README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Here is a typical snapshot of broadcast data returned by scanning for MiPs (on i
 
 - kCBAdvDataManufacturerData = 000501000000000000000000000000000000
 
-To know the difference between MiP and other BLE based products you can check the *Manufactorer Specific Data* which is sent as part of the advertising Packet. Check with your BLE framework on how to get this.
+To know the difference between MiP and other BLE based products you can check the *Manufacturer Specific Data* which is sent as part of the advertising Packet. Check with your BLE framework on how to get this.
 
-Each WowWee BLE product assigns a special 16bit ID in the first two bytes of the Manufactorer specific data. If you are using one of our prebuilt SDKs this is handled automatically for you.
+Each WowWee BLE product assigns a special 16bit ID in the first two bytes of the Manufacturer specific data. If you are using one of our prebuilt SDKs this is handled automatically for you.
 
 Taking the first 4 digits gives us a product ID of 5, all MiPs are assigned 5 as a product ID.
 
@@ -42,7 +42,7 @@ Taking the first 4 digits gives us a product ID of 5, all MiPs are assigned 5 as
 Please ignore these values, the only way to find the available services is by connecting to a MiP and scanning for services
 
 
-**Connecing to a MiP**
+**Connecting to a MiP**
 
 Please see your BLE framework for instructions on how to connect to a BLE device. Usually the framework will give you an object and a connect command. Your code should handle mundane tasks such as reconnecting, or handling a failed connection.
 
@@ -55,11 +55,11 @@ Bluetooth Low Energy is made up of a series of Services & Characteristics. In th
 - Send Data Service: 0xFFE5
   - Send Data WRITE Characteristic: 0xFFE9
   
-Using your Bluetooth Framework of choice you can choose to run a callback everytime you receive data using the Receive Data NOTIFY Characteristic.
+Using your Bluetooth Framework of choice you can choose to run a callback every time you receive data using the Receive Data NOTIFY Characteristic.
 
 _**IMPORTANT**_
 
-Please note that you can only find the above services once your connected to MiP. They will not show up in the broadcast data.
+Please note that you can only find the above services once you're connected to MiP. They will not show up in the broadcast data.
 
 Sending command bytes is very easy, just send a raw byte according to the value in the table.
 
@@ -67,7 +67,7 @@ Receiving commands on the other hand need some special treatment before they can
 
 ```objective-c
 // Get ASCII command value from incoming data
-NSString *ascii = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+NSString *asciiHex = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
 
 // Here we simply split the string array for every 2 characters
 NSMutableArray *theDataArray = [NSMutableArray array];
@@ -89,7 +89,7 @@ Note that this is just an example, you can use any language to processes command
 
 1. Convert the incoming string to ASCII
 2. Process the ASCII string and split it off every 2 characters, every two characters is a single incoming hex byte
-3. Convert each string set of hex characters into a integer value
+3. Convert each string set of hex characters into an integer value
 
 Process incoming integer values as you would normally based on the command protocol document.
 
@@ -114,7 +114,7 @@ Remember that this is a **String** so if you want to treat them as Integers, you
 
 **Using MiP via the onboard UART port**
 
-We have created a [seperate document with information and code samples](MiP-with-UART.md) for controlling MiP via the onboard serial port.
+We have created a [separate document with information and code samples](MiP-with-UART.md) for controlling MiP via the onboard serial port.
 
 **Exciting Projects**
 
@@ -123,7 +123,7 @@ We always love to share great projects that are built off of our libraries, so f
 * [libmip](https://github.com/arnaud-ramey/libmip) - A C library for controlling MiP, you can see a [demo video with joystick control here](https://www.youtube.com/watch?v=8p5-vwIeQ2g)
 * [Cyon-MiP](https://github.com/hybridgroup/cylon-mip) - A NodeJS library for controlling MiP
 * [Python Linux MiP](https://github.com/vlimit/mip) - Control MiP via BLE from Python running Linux
-* [Easy rechargeable MIP hack](https://hackaday.io/project/3316-putting-lipos-into-your-mip-robot) - Instructions for adding rechargable batteries to MiP
+* [Easy rechargeable MIP hack](https://hackaday.io/project/3316-putting-lipos-into-your-mip-robot) - Instructions for adding rechargeable batteries to MiP
 * [Hacking MiP by Sparkfun](https://learn.sparkfun.com/tutorials/hacking-the-mip---proto-back) - Great blog post with step by step instructions on how to connect via UART
 * [Raspberry Pi MiP](https://github.com/rjelbert/mip_robot/wiki) - Working with MiP using a Raspberry Pi
 * [EZ-Builder with MiP](http://www.ez-robot.com/Tutorials/Help.aspx?id=204) - [EZ-Builder](http://www.ez-robot.com) software can officially control MiP


### PR DESCRIPTION
Mostly just minor spelling mistakes that I noticed as I was reading
through the README to learn how to write my own MiP interfacing code.

I did rename a variable in the sample Objective-C code for converting
the hexadecimal response string to binary data.  The variable was
defined as ascii but future references were to asciiHex instead.