### PR TITLE
Add link to MiP C API

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,5 +128,6 @@ We always love to share great projects that are built off of our libraries, so f
 * [Raspberry Pi MiP](https://github.com/rjelbert/mip_robot/wiki) - Working with MiP using a Raspberry Pi
 * [EZ-Builder with MiP](http://www.ez-robot.com/Tutorials/Help.aspx?id=204) - [EZ-Builder](http://www.ez-robot.com) software can officially control MiP
 * [MiP with OSX](https://github.com/charcole/MiP-OSX) - Basic example of how to use MiP from OSX
+* [MiP C API](https://github.com/adamgreen/MiP-Capi#readme) - Console application development for OS X
 
 If you've developed your own library or project please send us a pull request!


### PR DESCRIPTION
C API to communicate with the MiP.  It currently just supports the
development of console applications on OS X communicating to the MiP
via BLE.

In the future I hope to add support for mbed
(http://developer.mbed.org) based microcontrollers communicating with
the MiP via the UART.