### PR TITLE
Add note about 9600 baud for newer MiPs

### DIFF
--- a/MiP-with-UART.md
+++ b/MiP-with-UART.md
@@ -9,7 +9,7 @@ MiP contains a UART serial port which can receive the same commands as the Bluet
 
 To connect to MiP you need to use these settings:
 
-* Baud Rate: 115200
+* Baud Rate: 115200 (9600 for newer MiP robots)
 * Flow Control: Off
 * Data Bits: 8
 * Parity Bit: None


### PR DESCRIPTION
Must connect to newer MiPs at 9600 baud when using the UART. This
commit notes this fact in the UART documentation. For more information
see issue #20.